### PR TITLE
Fixed scripts/preprocess to read config

### DIFF
--- a/scripts/preprocess
+++ b/scripts/preprocess
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+ROOT_DIRECTORY=$(realpath $(dirname $0)/../)
+
+# read variables in config file.
+. ${ROOT_DIRECTORY}/config
+
 ## check if installer has to be run by the superuser
 SUDO=
 if [ `ls -ld ${PREFIX} | cut -d " " -f 3` != `whoami` ]; then


### PR DESCRIPTION
As stated in the title,
there was a small problem in ``scripts/preprocess`` , which is called by ``script/install``.  
The problem is that the path value of `PREFIX` in the `config` file was not being reflected.  
On the other hand, it was being reflected in `script/build` which also requires `PREFIX`.    
So I added a few lines into `preprocess` so that it could be reflected `PREFIX` in the same way as `build`.