### PR TITLE
Adding and Modifying Scripts Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,12 @@ to download source codes from the Git repositories as zipped files, or
    ```sh
    % scripts/install git
    ```
-to clone the Git repositories. In the former case, the information about the
+to clone the Git repositories via SSH.
+If via HTTPS, run the following.
+   ```sh
+   % scripts/install git-https
+   ```
+In the former case, the information about the
 repositories is lost. It is followed by a process to compile and install the files.
 
 ### install files as debian packages

--- a/scripts/build
+++ b/scripts/build
@@ -20,7 +20,9 @@ fi
 
 cc=
 std=
-debug=
+if [ -z ${debug} ]; then
+  debug=
+fi
 
 # compile
 compile(){
@@ -75,6 +77,17 @@ makeclean(){
   fi
 }
 
+# dump all libinfo
+libsinfo(){
+  if [ -d ${lib} ]; then
+    cd ${lib}
+    LIBINFO=$(cat libinfo)
+    cd ${ROOT_DIRECTORY}
+    echo "${LIBINFO}" >> libsinfo
+    echo "" >> libsinfo
+  fi
+}
+
 cd ${ROOT_DIRECTORY}
 
 OPTION=$1
@@ -107,6 +120,14 @@ case $OPTION in
     do
       compile
     done
+    ;;
+  libsinfo)
+    rm -rf libsinfo
+    for lib in ${LIBS}
+    do
+      libsinfo
+    done
+    cat libsinfo
     ;;
   *)
     OPTION="default"

--- a/scripts/download
+++ b/scripts/download
@@ -32,8 +32,10 @@ git_clone_https(){
 ## git pull repositories
 git_pull(){
   echo "pulling" ${lib} "..."
+  cd ${lib}
   git fetch --all
   git pull
+  cd ${ROOT_DIRECTORY}
 }
 
 # main process

--- a/scripts/download
+++ b/scripts/download
@@ -32,6 +32,7 @@ git_clone_https(){
 ## git pull repositories
 git_pull(){
   echo "pulling" ${lib} "..."
+  git fetch --all
   git pull
 }
 

--- a/scripts/install
+++ b/scripts/install
@@ -14,6 +14,14 @@ case $OPTION in
     ${FILE_DIRECTORY}/download git
     ${FILE_DIRECTORY}/build
     ;;
+  git-https-cpp)
+    ${FILE_DIRECTORY}/download git-https
+    ${FILE_DIRECTORY}/build cpp
+    ;;
+  git-https)
+    ${FILE_DIRECTORY}/download git-https
+    ${FILE_DIRECTORY}/build
+    ;;
   deb)
     ${FILE_DIRECTORY}/download zip
     ${FILE_DIRECTORY}/build deb


### PR DESCRIPTION
Additions and Changes to Script Options

The following updates have been made.
- ``scripts/install``
  - Added the ``git-htttps`` and ``git-https-cpp`` options.
    Made the options from the ``download`` script available in ``install`` as well.
- ``scripts/download``  
  - Fixed a bug where the ``git-pull`` option was unable to retrieve the latest remote information.
- ``scripts/build``  
  - Modified the script so that the ``debug`` option now works via the environment variable ``${debug}``. This allows libraries to be installed in debug mode even when running such as ``debug=y ./scripts/install``.
  - Added the ``libsinfo`` option. This allows checking the version information for all libraries being compiled. The results are recorded (overwriting the existing file) in a text file named ``libsinfo`` in the top directory.